### PR TITLE
feat(main): add commit sha as output

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Check outputs
         run: |
           test "${{ steps.selftest.outputs.success }}" == "Artifact downloaded: ${{ github.sha }}"
+          test "${{ steps.selftest.outputs.commit }}" == "${{ github.sha }}"
           test -f foobar

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: 'An alternative name for the downloaded artifact'
   wait_seconds:
     description: 'Wait for the artifact to appear'
+outputs:
+  commit:
+    description: 'The commit sha corresponding to the artifact'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/main.py
+++ b/main.py
@@ -11,9 +11,7 @@ WAIT_SECONDS = int(os.getenv("INPUT_WAIT_SECONDS") or "60")
 WAIT_SLEEP = 0.5
 GITHUB_OUTPUT = os.environ["GITHUB_OUTPUT"]
 
-artifacts_url = (
-    f"https://api.github.com/repos/{REPO}/actions/artifacts?name={ARTIFACT_NAME}"
-)
+artifacts_url = f"https://api.github.com/repos/{REPO}/actions/artifacts"
 headers = {
     "Authorization": f"token {TOKEN}",
     "User-Agent": "Python",
@@ -32,10 +30,15 @@ def get_artifact(name):
     while waiting:
         if etag:
             resp = http.request(
-                "GET", artifacts_url, headers={**headers, "If-None-Match": etag}
+                "GET",
+                artifacts_url,
+                headers={**headers, "If-None-Match": etag},
+                fields={"name": ARTIFACT_NAME},
             )
         else:
-            resp = http.request("GET", artifacts_url, headers=headers)
+            resp = http.request(
+                "GET", artifacts_url, headers=headers, fields={"name": ARTIFACT_NAME}
+            )
             etag = resp.headers.get("etag")
 
         if resp.status == 200:

--- a/main.py
+++ b/main.py
@@ -49,13 +49,13 @@ def get_artifact(name):
 
 def set_output(name, value):
     with open(GITHUB_OUTPUT, "a") as github_output:
-        github_output.write("{}={}".format(name, value))
+        github_output.write(f"{name}={value}\n")
 
 
 def download_artifact(name, new_name):
     artifact = get_artifact(name)
     if artifact is None:
-        set_output("error", "Artifact not found: {}".format(name))
+        set_output("error", f"Artifact not found: {name}")
         exit(1)
 
     r = http.request("GET", artifact["archive_download_url"], headers=headers)

--- a/main.py
+++ b/main.py
@@ -11,7 +11,9 @@ WAIT_SECONDS = int(os.getenv("INPUT_WAIT_SECONDS") or "60")
 WAIT_SLEEP = 0.5
 GITHUB_OUTPUT = os.environ["GITHUB_OUTPUT"]
 
-artifacts_url = f"https://api.github.com/repos/{REPO}/actions/artifacts?name={NAME}"
+artifacts_url = (
+    f"https://api.github.com/repos/{REPO}/actions/artifacts?name={ARTIFACT_NAME}"
+)
 headers = {
     "Authorization": f"token {TOKEN}",
     "User-Agent": "Python",

--- a/main.py
+++ b/main.py
@@ -9,8 +9,9 @@ NAME = os.environ["INPUT_RENAME"] or ARTIFACT_NAME
 REPO = os.getenv("INPUT_REPO") or os.getenv("GITHUB_REPOSITORY")
 WAIT_SECONDS = int(os.getenv("INPUT_WAIT_SECONDS") or "60")
 WAIT_SLEEP = 0.5
+GITHUB_OUTPUT = os.environ["GITHUB_OUTPUT"]
 
-artifacts_url = f"https://api.github.com/repos/{REPO}/actions/artifacts"
+artifacts_url = f"https://api.github.com/repos/{REPO}/actions/artifacts?name={NAME}"
 headers = {
     "Authorization": f"token {TOKEN}",
     "User-Agent": "Python",
@@ -37,26 +38,29 @@ def get_artifact(name):
 
         if resp.status == 200:
             data = json.loads(resp.data.decode("utf-8"))
-            for artifact in data["artifacts"]:
-                print("Check artifact", artifact["name"])
-                if artifact["name"] == name:
-                    return artifact
+            return data["artifacts"][0] if data["artifacts"] else None
 
         waiting = time.time() - t_started < WAIT_SECONDS
         time.sleep(1)
         print("Waiting...", etag, resp.status)
 
 
+def set_output(name, value):
+    with open(GITHUB_OUTPUT, "a") as github_output:
+        github_output.write("{}={}".format(name, value))
+
+
 def download_artifact(name, new_name):
     artifact = get_artifact(name)
     if artifact is None:
-        print(f"::set-output name=error::Artifact not found: {name}")
+        set_output("error", "Artifact not found: {}".format(name))
         exit(1)
 
     r = http.request("GET", artifact["archive_download_url"], headers=headers)
     with open(new_name, "wb") as f:
         f.write(r.data)
-        print(f"::set-output name=success::Artifact downloaded: {artifact['name']}")
+        set_output("success", "Artifact downloaded: {}".format(artifact["name"]))
+        set_output("commit", artifact["workflow_run"]["head_sha"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Some workflows need to relate a build artifact to the commit they are based on, to be able to trace errors to the right version of the source etc. Adding this as an action output here, along with updating deprecated `set-output` (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and using `name` as a query parameter instead of manually filtering the reponse data.

Relates to https://bettermarks.atlassian.net/browse/CICD-37

## Type of change

- [ ] Bug fix
- [X] New feature 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

needs to be tested on GH actions