### PR TITLE
fix(action.yml): refer to action path when executing script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         INPUT_RENAME: ${{ inputs.rename }}
         INPUT_REPO: ${{ inputs.repo }}
         INPUT_WAIT_SECONDS: ${{ inputs.wait_seconds }}
-      run: python main.py
+      run: python "${{ github.action_path }}/main.py"
 
 branding:
   color: 'yellow'


### PR DESCRIPTION
# Description

Use `github.action` variable to refer to the path of the action, otherwise python script can't be found.

Relates to https://github.com/bettermarks/local-dev-stack/actions/runs/6529371257/job/17726922067

## Type of change

- [X] Bug fix
- [ ] New feature 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

CI
